### PR TITLE
GTFO dependency fix

### DIFF
--- a/src/main/java/gtb/api/GTBInternalTags.java
+++ b/src/main/java/gtb/api/GTBInternalTags.java
@@ -3,7 +3,7 @@ package gtb.api;
 public class GTBInternalTags {
 
     public static final String VERSION = "0.1-beta";
-    public static final String GT_VERSION_STRING = "required-after:gregtech@[2.8.8-beta,);required-after:gcym@[1.2.8-beta,);required-after:gregtech-food-option@[1.11.1,)";
+    public static final String GT_VERSION_STRING = "required-after:gregtech@[2.8.8-beta,);required-after:gcym@[1.2.8-beta,);required-after:gregtechfoodoption@[1.11.1,)";
 
     private GTBInternalTags() {}
 }


### PR DESCRIPTION
This PR fixes the not finding gregtech food option at launch time.
This was due to wrong modid `gregtech-food-option` instead of `gregtechfoodoption`.